### PR TITLE
Add Prometheus metrics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,4 @@ COPY . .
 
 RUN pip install --break-system-packages -r requirements.txt
 
-CMD ["uvicorn", "proxy:app", "--host=127.0.0.1", "--port=8888"]
+CMD ["python3", "proxy.py"]

--- a/README.md
+++ b/README.md
@@ -44,3 +44,7 @@ There are two env variables to control the cache.
 When deploying with docker take care to use a volume so the cache is not lost on restarts.
 
 `KPROXY_CACHE_DISABLE` to entirely disable the cache.
+
+### Metrics
+
+A prometheus http server with metrics will listen in http://127.0.0.1:9999

--- a/cache.py
+++ b/cache.py
@@ -7,7 +7,7 @@ from types import NoneType
 
 import diskcache
 
-logger = logging.getLogger()
+logger = logging.getLogger("proxy.cache")
 
 VERSION = 1
 VERSION_CACHE_KEY = "VERSION"

--- a/metrics.py
+++ b/metrics.py
@@ -1,0 +1,32 @@
+from prometheus_client import Counter, Histogram, start_http_server
+
+rpc_requests_total = Counter(
+    "rpc_requests_total",
+    documentation="Total rpc requests processed",
+    labelnames=["status_code", "rpc_method", "blockchain", "cached"],
+)
+
+http_request_duration_s = Histogram(
+    "http_request_duration_s",
+    documentation="HTTP request processing duration in seconds",
+)
+http_errors_total = Counter(
+    "http_errors_total",
+    documentation="Total HTTP requests resulting in errors",
+)
+upstream_requests_total = Counter(
+    name="http_upstream_requests_total",
+    documentation="Total requests to upstream servers",
+    labelnames=["upstream_node", "rpc_method"],
+)
+upstream_latency_s = Histogram(
+    name="http_upstream_latency_s",
+    documentation="Latency of upstream server in seconds",
+    labelnames=["upstream_node"],
+)
+
+upstream_errors_total = Counter(
+    name="upstream_errors_total",
+    documentation="Total upstream requests resulting in errors",
+    labelnames=["upstream_node"]
+)

--- a/proxy.py
+++ b/proxy.py
@@ -13,10 +13,14 @@ from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 from starlette.routing import Route
+from starlette.middleware import Middleware
+from starlette.middleware.base import BaseHTTPMiddleware
+import uvicorn
 
+import metrics
 from cache import is_cache_enabled, is_cacheable, cache, generate_cache_key
 
-logger = logging.getLogger()
+logger = logging.getLogger("proxy")
 
 MAX_UPSTREAM_TRIES_FOR_REQUEST = 5
 MAX_HTTP_CONNECTIONS = 10
@@ -57,7 +61,6 @@ class UpstreamNode:
         self.endpoint = endpoint
         self.client = httpx.AsyncClient(limits=httpx_limits)
         self.status: NodeStatus = NodeStatus.HEALTHY
-        self._last_latency = None
 
         async def check_loop():
             while True:
@@ -85,18 +88,13 @@ class UpstreamNode:
             await self.make_request(data)
         except Exception:
             pass
-        self._last_latency = time.monotonic() - start
 
     async def make_request(self, data: dict) -> httpx.Response:
         try:
             response = await self.client.post(self.endpoint, json=data)
-        except httpx.HTTPError as exc:
+        except (httpx.HTTPError, anyio.EndOfStream) as exc:
             self.status = NodeStatus.UNHEALTHY
-            logger.warning(f"httpx.HTTPError {repr(exc)} for {self}")
-            raise NodeNotHealthy(f"{self} {exc}")
-        except anyio.EndOfStream as exc:
-            self.status = NodeStatus.UNHEALTHY
-            logger.warning(f"anyio.EndOfStream {exc} for {self}")
+            logger.warning(f"{repr(exc)} for {self}")
             raise NodeNotHealthy(f"{self} {exc}")
 
         if response.status_code != 200:
@@ -158,7 +156,7 @@ async def make_request(node: UpstreamNode, blockchain: str, data: dict):
         return resp_data
     else:
         key, data = cache[cache_key]
-        return {"jsonrpc": "2.0", "id": 11, key: data}
+        return {"jsonrpc": "2.0", "id": 11, key: data, "cached": True}
 
 
 def error_response(request_data, code, message, data=None):
@@ -166,6 +164,10 @@ def error_response(request_data, code, message, data=None):
     if data is not None:
         resp["error"]["data"] = data
     return JSONResponse(content=resp)
+
+
+def set_metric_ctx(request, key, value):
+    request.scope["metrics_ctx"][key] = value
 
 
 async def root(request: Request):
@@ -180,16 +182,34 @@ async def root(request: Request):
     if blockchain not in ENDPOINTS:
         return error_response(request_data, code=404, message=f"No RPC nodes for blockchain {blockchain}")
 
+    set_metric_ctx(request, key="rpc", value=True)
+    set_metric_ctx(request, key="blockchain", value=blockchain)
+    set_metric_ctx(request, key="method", value=request_data.get("method", "unknown"))
+
     for upstream_try in range(MAX_UPSTREAM_TRIES_FOR_REQUEST):
         node = get_upstream_node_for_blockchain(blockchain)
         logger.info(f"Get request for '{blockchain}' to {node.endpoint}, try {upstream_try}, with data: {request_data!s:.100}")
+        error = False
+        start_time = time.monotonic()
         try:
+            metrics.upstream_requests_total.labels(upstream_node=node.endpoint,
+                                                   rpc_method=request_data.get("method", "unknown")).inc()
             upstream_data = await make_request(node, blockchain, request_data)
+
             upstream_data["id"] = request_data["id"]
         except NodeNotHealthy:
-            continue
+            error = True
+        finally:
+            metrics.upstream_latency_s.labels(upstream_node=node.endpoint).observe(time.monotonic() - start_time)
+            if error:
+                continue
+
         logger.info(f"Response for '{blockchain}' with data: {upstream_data!s:.100}")
+        set_metric_ctx(request, key="upstream_tries", value=upstream_try + 1)
+        set_metric_ctx(request, key="cached", value=upstream_data.pop("cached", False))
         return JSONResponse(content=upstream_data)
+
+    set_metric_ctx(request, key="error", value=502)
     return error_response(request_data, code=502, message="Can't get a good response from upstream nodes")
 
 
@@ -201,9 +221,100 @@ routes = [
     Route("/{blockchain}", endpoint=root, methods=["POST"]),
 ]
 
-app = Starlette(routes=routes)
 
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+class MetricsMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request, call_next):
+        start_time = time.monotonic()
 
-if not AUTHORIZED_KEYS:
-    logging.warning("No AUTHORIZED_KEYS configured, everyone with access can use the service!")
+        response = await call_next(request)
+
+        print(request.scope["metrics_ctx"])
+        duration = time.monotonic() - start_time
+        metrics.http_request_duration_s.observe(duration)
+        metrics.http_requests_total.labels(status_code=str(response.status_code)).inc()
+        if response.status_code != 200:
+            metrics.http_errors_total.inc()
+        return response
+
+
+class MonitoringMiddleware:
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            return await self.app(scope, receive, send)
+
+        scope["metrics_ctx"] = {}
+        start_time = time.monotonic()
+        try:
+            await self.app(scope, receive, send)
+        finally:
+            duration = time.monotonic() - start_time
+            metrics.http_request_duration_s.observe(duration)
+            if "rpc" in scope["metrics_ctx"]:
+                status = str(scope["metrics_ctx"].get("error", 200))
+                blockchain = scope["metrics_ctx"].get("blockchain")
+                cached = scope["metrics_ctx"].get("cached")
+                method = scope["metrics_ctx"].get("method")
+                metrics.rpc_requests_total.labels(status_code=status,
+                                                  rpc_method=method,
+                                                  blockchain=blockchain,
+                                                  cached=cached).inc()
+
+                if status != 200:
+                    metrics.http_errors_total.inc()
+
+
+middleware = [
+    Middleware(MonitoringMiddleware)
+]
+
+app = Starlette(routes=routes, middleware=middleware)
+
+if __name__ == "__main__":
+    if not AUTHORIZED_KEYS:
+        logging.warning("No AUTHORIZED_KEYS configured, everyone with access can use the service!")
+
+    logger.info("Prometheus metrics HTTP running on http://127.0.0.1:9999")
+    metrics.start_http_server(addr="127.0.0.1", port=9999)
+
+    # TODO: in depth review of the logging config
+    log_cfg = {
+        "version": 1,
+        "disable_existing_loggers": True,
+        "formatters": {
+            "standard": {"format": "%(asctime)s [%(levelname)s] %(name)s: %(message)s"},
+        },
+        "handlers": {
+            "default": {
+                "level": "INFO",
+                "formatter": "standard",
+                "class": "logging.StreamHandler",
+                "stream": "ext://sys.stdout",
+            },
+        },
+        "loggers": {
+            "": {
+                "level": "INFO",
+                "handlers": [],
+                "propagate": True,
+            },
+            "proxy": {
+                "level": "INFO",
+                "handlers": ["default"],
+                "propagate": False,
+            },
+            "uvicorn.error": {
+                "level": "DEBUG",
+                "handlers": ["default"],
+                "propagate": False,
+            },
+            "uvicorn.access": {
+                "level": "DEBUG",
+                "handlers": ["default"],
+            },
+        },
+    }
+    print(logger)
+    uvicorn.run(app, port=8888, log_level="info", log_config=log_cfg)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ starlette>=0.37.1
 uvicorn[standard]
 httpx
 diskcache
+prometheus_client


### PR DESCRIPTION
A prometheus http server with metrics will listen in http://127.0.0.1:9999

Take in consideration that the metrics will include the upstream endopoint as a tag (that has the key). So the server should only be accesible to the prometheus data gatherere and not to everyone.