### PR TITLE
Change routing and better error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Pass an env variable with the authorized keys in the following format when runni
 
 Then access the node as foolows:
 
-`https://mynode.com/ethereum?key=my-secret-key1`
+`https://mynode.com/chain/ethereum?key=my-secret-key1`
 
 ### Cache
 

--- a/proxy.py
+++ b/proxy.py
@@ -14,7 +14,6 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 from starlette.routing import Route
 from starlette.middleware import Middleware
-from starlette.middleware.base import BaseHTTPMiddleware
 import uvicorn
 
 import metrics
@@ -225,21 +224,6 @@ routes = [
     Route("/status", endpoint=status, methods=["GET"]),
     Route("/{blockchain}", endpoint=root, methods=["POST"]),
 ]
-
-
-class MetricsMiddleware(BaseHTTPMiddleware):
-    async def dispatch(self, request, call_next):
-        start_time = time.monotonic()
-
-        response = await call_next(request)
-
-        print(request.scope["metrics_ctx"])
-        duration = time.monotonic() - start_time
-        metrics.http_request_duration_s.observe(duration)
-        metrics.http_requests_total.labels(status_code=str(response.status_code)).inc()
-        if response.status_code != 200:
-            metrics.http_errors_total.inc()
-        return response
 
 
 class MonitoringMiddleware:

--- a/proxy.py
+++ b/proxy.py
@@ -226,7 +226,7 @@ for network, endpoints in config['nodes'].items():
 
 routes = [
     Route("/status", endpoint=status, methods=["GET"]),
-    Route("/{blockchain}", endpoint=node_rpc, methods=["POST"]),
+    Route("/chain/{blockchain}", endpoint=node_rpc, methods=["POST"]),
 ]
 
 

--- a/proxy.py
+++ b/proxy.py
@@ -169,8 +169,12 @@ def set_metric_ctx(request, key, value):
     request.scope["metrics_ctx"][key] = value
 
 
-async def root(request: Request):
-    request_data = await request.json()
+async def node_rpc(request: Request):
+    try:
+        request_data = await request.json()
+    except json.JSONDecodeError:
+        return error_response({"id": None}, code=-32700, message="Parse error")
+
     if AUTHORIZED_KEYS:
         key = request.query_params.get("key", "")
         if key not in AUTHORIZED_KEYS:
@@ -222,7 +226,7 @@ for network, endpoints in config['nodes'].items():
 
 routes = [
     Route("/status", endpoint=status, methods=["GET"]),
-    Route("/{blockchain}", endpoint=root, methods=["POST"]),
+    Route("/{blockchain}", endpoint=node_rpc, methods=["POST"]),
 ]
 
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -5,7 +5,7 @@ import httpx
 
 import cache
 import proxy
-from tests.utils import PROXY_URL, fake_upstream, proxy_server, get_node
+from tests.utils import PROXY_URL, fake_upstream, proxy_server, get_proxy_eth_node
 
 logger = logging.getLogger()
 
@@ -13,7 +13,7 @@ cache.cache_enable(False)
 
 
 def test_get_balance_real_upstream(proxy_server):
-    w3 = get_node(PROXY_URL + "ethereum")
+    w3 = get_proxy_eth_node()
 
     # {'jsonrpc': '2.0', 'method': 'eth_getBalance', 'params': ['0x6CF63938f2CD5DFEBbDE0010bb640ed7Fa679693', '0x1272617'], 'id': 1}
     balance = w3.eth.get_balance("0x6CF63938f2CD5DFEBbDE0010bb640ed7Fa679693", block_identifier=19342871)
@@ -21,13 +21,13 @@ def test_get_balance_real_upstream(proxy_server):
 
 
 def test_chain_id_real_upstream(proxy_server):
-    w3 = get_node(PROXY_URL + "ethereum")
+    w3 = get_proxy_eth_node()
     assert w3.eth.chain_id == 1
 
 
 def test_get_balance(proxy_server, fake_upstream):
     with patch.object(proxy, "get_upstream_node_for_blockchain", lambda b: fake_upstream.node):
-        w3 = get_node(PROXY_URL + "ethereum")
+        w3 = get_proxy_eth_node()
 
         fake_upstream.add_responses([
             ({'jsonrpc': '2.0', 'id': 1, 'result': '0x1'}, 200),
@@ -47,7 +47,7 @@ def test_with_fake_node_500_error(proxy_server, fake_upstream):
             {'jsonrpc': '2.0', 'id': req_id, 'error': {"code": -32003, "message": "Transaction rejected"}},
             500)
 
-        response = httpx.post(PROXY_URL + "ethereum",
+        response = httpx.post(PROXY_URL + "chain/ethereum",
                               json={'jsonrpc': '2.0', 'method': 'eth_getBalance',
                                     'params': ['0x6CF63938f2CD5DFEBbDE0010bb640ed7Fa679693', '0x1272619'], 'id': req_id})
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -98,3 +98,6 @@ def get_node(url):
     provider = HTTPProviderNoRetry(url)
     w3 = web3.Web3(provider)
     return w3
+
+def get_proxy_eth_node():
+    return get_node(PROXY_URL + "chain/ethereum")


### PR DESCRIPTION
Improve the error handling so it does not raise error 500 when a malformed json arrives.

:red_square:  **Backward incompatible change: ** :red_square:  

* Moved the rpc interface from `/` to `/chain/`  so now it must be used `/chain/ethereum`, etc. 
